### PR TITLE
Reworked install target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.2.0 FATAL_ERROR)
 
 # https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/
 
@@ -7,8 +7,8 @@ cmake_minimum_required(VERSION 3.11.0 FATAL_ERROR)
 
 # Set the variables before the project definition to get their
 # default values int the cmake cache.
-set( CMAKE_BUILD_TYPE "Release" CACHE STRING "Default.")
-set( CMAKE_INSTALL_PREFIX "./dist" CACHE STRING "Default.")
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Default.")
+set(CMAKE_INSTALL_PREFIX "./dist" CACHE STRING "Default.")
 
 project(smack_cpp VERSION 0.1.0 LANGUAGES CXX)
 
@@ -31,18 +31,5 @@ if (ENABLE_EXAMPLES)
 endif ()
 
 if (ENABLE_TESTS)
-    include(FetchContent)
-	
-    FetchContent_Declare(
-      googletest
-      GIT_REPOSITORY https://github.com/google/googletest.git
-      GIT_TAG        release-1.10.0
-    )
-
-    # After the following call, the CMake targets defined by googletest
-    # are available to the rest of the build.
-    FetchContent_MakeAvailable(googletest)
-
-    enable_testing()
     add_subdirectory(test)
 endif ()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,21 @@
-﻿cmake_minimum_required(VERSION 3.2.0 FATAL_ERROR)
+﻿cmake_minimum_required(VERSION 3.11.0 FATAL_ERROR)
+
+enable_testing()
+
+option(INSTALL_GTEST "Include gtest in product install." OFF)
+option(INSTALL_GMOCK "Include gmock in product install." OFF)
+
+include(FetchContent)
+	
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        release-1.10.0
+)
+
+# After the following call, the CMake targets defined by googletest
+# are available to the rest of the build.
+FetchContent_MakeAvailable(googletest)
 
 set(headers
   test_common.hpp


### PR DESCRIPTION
* All test-related configurations were moved to test/CMakeLists.txt.
* Globally required cmake version adjusted from 3.11 to 3.2.
* Verified: Result of 'make install' is created in `$BUILD_DIR/dist/`.

Fixes #56 .